### PR TITLE
Update the `check_period` column of `tailscale_acl_ssh` table to be string type  instead of timestamp closes #32

### DIFF
--- a/tailscale/table_tailscale_acl_ssh.go
+++ b/tailscale/table_tailscale_acl_ssh.go
@@ -41,7 +41,7 @@ func tableTailscaleAclSSH(_ context.Context) *plugin.Table {
 			{
 				Name:        "check_period",
 				Description: "The time period for which the connection remains in check mode.",
-				Type:        proto.ColumnType_TIMESTAMP,
+				Type:        proto.ColumnType_STRING,
 			},
 		}),
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from tailscale_acl_ssh
+--------+-----------------------------------------------+-----------------------+---------------------+--------------+--------------+---------------------------------+
| action | users                                         | source                | destination         | check_period | tailnet_name | _ctx                            |
+--------+-----------------------------------------------+-----------------------+---------------------+--------------+--------------+---------------------------------+
| check  | ["group:developer"]                           | ["group:developer"]   | ["tag:prod"]        | 20h          | turbot.com   | {"connection_name":"tailscale"} |
| accept | ["autogroup:nonroot","root"]                  | ["autogroup:members"] | ["autogroup:self"]  | 20h          | turbot.com   | {"connection_name":"tailscale"} |
| accept | ["group:developer","group:admin","group:ops"] | ["tag:personal"]      | ["tag:development"] | 20h          | turbot.com   | {"connection_name":"tailscale"} |
+--------+-----------------------------------------------+-----------------------+---------------------+--------------+--------------+---------------------------------+
```
</details>
