### PR TITLE
Added column `tailnet_name` to `tailscale_tailnet_key` table

### DIFF
--- a/tailscale/table_tailscale_tailnet_key.go
+++ b/tailscale/table_tailscale_tailnet_key.go
@@ -23,7 +23,7 @@ func tableTailscaleTailnetKey(_ context.Context) *plugin.Table {
 				},
 			},
 		},
-		Columns: []*plugin.Column{
+		Columns: defaultColumns([]*plugin.Column{
 			{
 				Name:        "id",
 				Description: "An unique identifier of the tailnet key.",
@@ -59,7 +59,7 @@ func tableTailscaleTailnetKey(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Key"),
 			},
-		},
+		}),
 	}
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from tailscale_tailnet_key where id='kFXfcN2CMDR'
+--------------+--------+---------------------------+---------------------------+-----------------------------------------------------------------------------------------------+-------+--------------+----
| id           | key    | created                   | expires                   | capabilities                                                                                  | title | tailnet_name | _ct
+--------------+--------+---------------------------+---------------------------+-----------------------------------------------------------------------------------------------+-------+--------------+----
| kFXfcN2CMDR | <null> | 2022-09-19T14:09:40+05:30 | 2022-12-18T14:09:40+05:30 | {"devices":{"create":{"ephemeral":false,"preauthorized":true,"reusable":false,"tags":null}}} |       | turbot.com   |
```
</details>
