### PR TITLE
Fix the query formatting in table docs

### DIFF
--- a/docs/tables/tailscale_acl_entry.md
+++ b/docs/tables/tailscale_acl_entry.md
@@ -86,7 +86,7 @@ with src_dest as (
     jsonb_array_elements_text(tags) as tag
 ), all_devices as (
   select
-    td.name as device_name, 
+    td.name as device_name,
     tag,
     td.addresses ->> 0 as ipv4,
     td.addresses ->> 1 as ipv6,

--- a/docs/tables/tailscale_acl_ssh.md
+++ b/docs/tables/tailscale_acl_ssh.md
@@ -33,8 +33,8 @@ with ssh_tas as (
     jsonb_array_elements_text(source) as src,
     jsonb_array_elements_text(destination) as dst
   where
-    action <> 'check' 
-    or  src <> 'autogroup:members'
+    action <> 'check'
+    or src <> 'autogroup:members'
     or dst <> 'autogroup:self'
 )
 select
@@ -42,7 +42,8 @@ select
   td.user,
   td.id
 from
-  tailscale_device as td join ssh_tas on ssh_tas.tailnet_name = td.tailnet_name;
+  tailscale_device as td
+  join ssh_tas on ssh_tas.tailnet_name = td.tailnet_name;
 ```
 
 ### Users who are a direct member (not a shared user) of the tailnet
@@ -67,7 +68,8 @@ select
   td.name as device_name,
   td.id
 from
-  tailscale_device as td join ssh_tas on ssh_tas.tailnet_name = td.tailnet_name;
+  tailscale_device as td
+  join ssh_tas on ssh_tas.tailnet_name = td.tailnet_name;
 ```
 
 ### Users who have the check period disabled
@@ -77,6 +79,8 @@ select
   tas.users,
   tas.action
 from
-  tailscale_acl_ssh as tas join tailscale_tailnet as tt on tas.tailnet_name = tt.tailnet_name and action = 'accept'
+  tailscale_acl_ssh as tas 
+  join tailscale_tailnet as tt on tas.tailnet_name = tt.tailnet_name
+  and action = 'accept'
   and check_period is null;
 ```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
